### PR TITLE
Clean up extract and surround $1 with double quotes

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -90,19 +90,16 @@ man() {
 }
 
 extract () {
-    if [ -f $1 ] ; then
-      case $1 in
-        *.tar.bz2)   tar xjf $1     ;;
-        *.tar.gz)    tar xzf $1     ;;
-        *.bz2)       bunzip2 $1     ;;
-        *.rar)       7z x $1        ;;
-        *.gz)        gunzip $1      ;;
-        *.tar)       tar xf $1      ;;
-        *.tbz2)      tar xjf $1     ;;
-        *.tgz)       tar xzf $1     ;;
-        *.zip)       unzip $1       ;;
-        *.Z)         uncompress $1  ;;
-        *.7z)        7z x $1        ;;
+    if [ -f "$1" ] ; then
+      case "$1" in
+        *.tar.bz2|*.tbz2)   tar xjf "$1"     ;;
+        *.tgz|*.tar.gz)     tar xzf "$1"     ;;
+        *.bz2)              bunzip2 "$1"     ;;
+        *.7z|.rar)          7z x "$1"        ;;
+        *.gz)               gunzip "$1"      ;;
+        *.tar)              tar xf "$1"      ;;
+        *.zip)              unzip "$1"       ;;
+        *.Z)                uncompress "$1"  ;;
         *)     echo "'$1' cannot be extracted via extract()" ;;
          esac
      else


### PR DESCRIPTION
Surrounding $1 with double quotes prevents word splitting and you can have multiple cases within one line for the same exact action.